### PR TITLE
Sometimes ESP C4 Bugged

### DIFF
--- a/memory-external/hacks/hack.hpp
+++ b/memory-external/hacks/hack.hpp
@@ -42,10 +42,7 @@ namespace hack {
 
 			/**
 			* Sometimes C4 Position bugged if you look behind the C4, or C4 Screen Pos not in Screen Area
-			* 
-			* Tested in my side
 			*/
-
 			if (c4ScreenPos.z >= 0.01f) {
 				float distance = localOrigin.calculate_distance(c4Origin);
 				float roundedDistance = std::round(distance / 500.f);

--- a/memory-external/hacks/hack.hpp
+++ b/memory-external/hacks/hack.hpp
@@ -40,29 +40,37 @@ namespace hack {
 
 			const Vector3 c4ScreenPos = c4Origin.world_to_screen(view_matrix);
 
-			float distance = localOrigin.calculate_distance(c4Origin);
-			float roundedDistance = std::round(distance / 500.f);
+			/**
+			* Sometimes C4 Position bugged if you look behind the C4, or C4 Screen Pos not in Screen Area
+			* 
+			* Tested in my side
+			*/
 
-			float height = 10 - roundedDistance;
-			float width = height * 1.4f;
+			if (c4ScreenPos.z >= 0.01f) {
+				float distance = localOrigin.calculate_distance(c4Origin);
+				float roundedDistance = std::round(distance / 500.f);
 
-			render::DrawFilledBox(
-				g::hdcBuffer,
-				c4ScreenPos.x - (width / 2),
-				c4ScreenPos.y - (height / 2),
-				width,
-				height,
-				config::esp_box_color_enemy
-			);
+				float height = 10 - roundedDistance;
+				float width = height * 1.4f;
 
-			render::RenderText(
-				g::hdcBuffer,
-				c4ScreenPos.x + (width / 2 + 5),
-				c4ScreenPos.y,
-				"C4",
-				config::esp_name_color,
-				10
-			);
+				render::DrawFilledBox(
+					g::hdcBuffer,
+					c4ScreenPos.x - (width / 2),
+					c4ScreenPos.y - (height / 2),
+					width,
+					height,
+					config::esp_box_color_enemy
+				);
+
+				render::RenderText(
+					g::hdcBuffer,
+					c4ScreenPos.x + (width / 2 + 5),
+					c4ScreenPos.y,
+					"C4",
+					config::esp_name_color,
+					10
+				);
+			}
 		}
 
 		int playerIndex = 0;


### PR DESCRIPTION
I was tried, if c4 position not in screen area. ESP C4 drawed in wrong position. Maybe we can check the position first. If the position in screen area, render/draw the ESP C4.

![Screenshot_20](https://github.com/IMXNOOBX/cs2-external-esp/assets/67111486/12b1ecee-57f3-4ce3-9bb8-8627a8bed83f)

