### PR TITLE
memory improvement, fix python update offsets, change compiler params

### DIFF
--- a/memory-external/memory-external.vcxproj
+++ b/memory-external/memory-external.vcxproj
@@ -177,12 +177,14 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>gdiplus.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -195,12 +197,14 @@
       <PreprocessorDefinitions>NDEBUG;_UC;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>gdiplus.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/offsets/update_offsets.py
+++ b/offsets/update_offsets.py
@@ -5,7 +5,7 @@ import re
 
 source_url = "https://github.com/a2x/cs2-dumper/raw/main/generated/offsets.json"
 commits_url = "https://api.github.com/repos/a2x/cs2-dumper/commits"
-dest_path = "./offsets/offsets.json"
+dest_path = "./offsets.json"
 
 # Fetch the source JSON
 source_response = requests.get(source_url)
@@ -33,10 +33,10 @@ if dest_data["build_number"] == int(build_number):
 
 dest_data["build_number"] = int(build_number)
 
-dest_data["dwBuildNumber"] = source_data["Engine2Dll"]["data"]["dwBuildNumber"]["value"]
-dest_data["dwLocalPlayer"] = source_data["ClientDll"]["data"]["dwLocalPlayerPawn"]["value"]
-dest_data["dwEntityList"] = source_data["ClientDll"]["data"]["dwEntityList"]["value"]
-dest_data["dwViewMatrix"] = source_data["ClientDll"]["data"]["dwViewMatrix"]["value"]
+dest_data["dwBuildNumber"] = source_data["engine_2dll"]["data"]["dwBuildNumber"]["value"]
+dest_data["dwLocalPlayer"] = source_data["client_dll"]["data"]["dwLocalPlayerPawn"]["value"]
+dest_data["dwEntityList"] = source_data["client_dll"]["data"]["dwEntityList"]["value"]
+dest_data["dwViewMatrix"] = source_data["client_dll"]["data"]["dwViewMatrix"]["value"]
 
 with open(dest_path, 'w') as dest_file:
     json.dump(dest_data, dest_file, indent=4)


### PR DESCRIPTION
use native api instead of standard winapi
fix update_offsets.py
add multiprocessor compilations
change linking method

Judging by the tests, I can say with confidence that using the Native API directly is much faster in operation than WinAPI.