### PR TITLE
Add show_basic_flags to config

### DIFF
--- a/memory-external/classes/config.cpp
+++ b/memory-external/classes/config.cpp
@@ -36,6 +36,8 @@ namespace config {
 			flag_render_distance = data["flag_render_distance"];
 		if (data["show_extra_flags"].is_boolean())
 			show_extra_flags = data["show_extra_flags"];
+		if (data["show_basic_flags"].is_boolean())
+			show_basic_flags = data["show_basic_flags"];
 
 		if (data.find("esp_box_color_team") != data.end()) {
 			esp_box_color_team = {
@@ -104,6 +106,7 @@ namespace config {
 		data["render_distance"] = render_distance;
 		data["flag_render_distance"] = flag_render_distance;
 		data["show_extra_flags"] = show_extra_flags;
+		data["show_basic_flags"] = show_basic_flags;
 
 		data["esp_box_color_team"] = { esp_box_color_team.r, esp_box_color_team.g, esp_box_color_team.b };
 		data["esp_box_color_enemy"] = { esp_box_color_enemy.r, esp_box_color_enemy.g, esp_box_color_enemy.b };

--- a/memory-external/classes/config.hpp
+++ b/memory-external/classes/config.hpp
@@ -31,6 +31,7 @@ namespace config {
 	inline bool show_skeleton_esp = false;
 	inline bool show_head_tracker = false;
 	inline bool show_extra_flags = false;
+	inline bool show_basic_flags = true;
 
 	inline RGB esp_box_color_team = { 75, 175, 75 };
 	inline RGB esp_box_color_enemy = { 225, 75, 75 };

--- a/memory-external/hacks/hack.hpp
+++ b/memory-external/hacks/hack.hpp
@@ -120,68 +120,72 @@ namespace hack {
 				);
 			}
 
-			render::DrawBorderBox(
-				g::hdcBuffer,
-				screenHead.x - (width / 2 + 10),
-				screenHead.y + (height * (100 - player->armor) / 100),
-				2,
-				height - (height * (100 - player->armor) / 100),
-				RGB(0, 185, 255)
-			);
+			if (config::show_basic_flags)
+			{
+				render::DrawBorderBox(
+					g::hdcBuffer,
+					screenHead.x - (width / 2 + 10),
+					screenHead.y + (height * (100 - player->armor) / 100),
+					2,
+					height - (height * (100 - player->armor) / 100),
+					RGB(0, 185, 255)
+				);
 
-			render::DrawBorderBox(
-				g::hdcBuffer,
-				screenHead.x - (width / 2 + 5),
-				screenHead.y + (height * (100 - player->health) / 100),
-				2,
-				height - (height * (100 - player->health) / 100),
-				RGB(
-					(255 - player->health),
-					(55 + player->health * 2),
-					75
-				)
-			);
+				render::DrawBorderBox(
+					g::hdcBuffer,
+					screenHead.x - (width / 2 + 5),
+					screenHead.y + (height * (100 - player->health) / 100),
+					2,
+					height - (height * (100 - player->health) / 100),
+					RGB(
+						(255 - player->health),
+						(55 + player->health * 2),
+						75
+					)
+				);
 
-			render::RenderText(
-				g::hdcBuffer,
-				screenHead.x + (width / 2 + 5),
-				screenHead.y,
-				player->name.c_str(),
-				config::esp_name_color,
-				10
-			);
+				render::RenderText(
+					g::hdcBuffer,
+					screenHead.x + (width / 2 + 5),
+					screenHead.y,
+					player->name.c_str(),
+					config::esp_name_color,
+					10
+				);
+				
+				/**
+				* I know is not the best way but a simple way to not saturate the screen with a ton of information
+				*/
+				if (roundedDistance > config::flag_render_distance)
+					continue;
 
-			/**
-			* I know is not the best way but a simple way to not saturate the screen with a ton of information
-			*/
-			if (roundedDistance > config::flag_render_distance)
-				continue;
+				render::RenderText(
+					g::hdcBuffer,
+					screenHead.x + (width / 2 + 5),
+					screenHead.y + 10,
+					(std::to_string(player->health) + "hp").c_str(),
+					RGB(
+						(255 - player->health),
+						(55 + player->health * 2),
+						75
+					),
+					10
+				);
 
-			render::RenderText(
-				g::hdcBuffer,
-				screenHead.x + (width / 2 + 5),
-				screenHead.y + 10,
-				(std::to_string(player->health) + "hp").c_str(),
-				RGB(
-					(255 - player->health),
-					(55 + player->health * 2),
-					75
-				),
-				10
-			);
+				render::RenderText(
+					g::hdcBuffer,
+					screenHead.x + (width / 2 + 5),
+					screenHead.y + 20,
+					(std::to_string(player->armor) + "armor").c_str(),
+					RGB(
+						(255 - player->armor),
+						(55 + player->armor * 2),
+						75
+					),
+					10
+				);
+			}
 
-			render::RenderText(
-				g::hdcBuffer,
-				screenHead.x + (width / 2 + 5),
-				screenHead.y + 20,
-				(std::to_string(player->armor) + "armor").c_str(),
-				RGB(
-					(255 - player->armor),
-					(55 + player->armor * 2),
-					75
-				),
-				10
-			);
 
 			if (config::show_extra_flags)
 			{


### PR DESCRIPTION
Allows people to disable the health bars and text that previously always (unless out of range) showed up via the config, on by default